### PR TITLE
removed source_ref and changed object from ref to directly included

### DIFF
--- a/data-model/stix/observation.json
+++ b/data-model/stix/observation.json
@@ -9,13 +9,9 @@
     },
     {
       "properties": {
-        "source_ref": {
-          "type": "string",
-          "description": "The ID of the entity doing the observing."
-        },
-        "object_ref": {
-          "type": "string",
-          "description": "Reference to the object that this matches against."
+        "object": {
+          "type": "object",
+          "description": "CybOX object definition that was observed."
         },
         "observed_at": {
           "type": "array",


### PR DESCRIPTION
My reasoning:
1. `source_ref` is not required because all top-level objects already include `producer`
2. `object_ref` should actually be a full CybOX object because "bare" CybOX objects are not top-level nodes in the relationship graph (rather, usages of them - like this - are).
