### PR TITLE
Adding Referenceable and Asset Object

### DIFF
--- a/data-model/common/referenceable.json
+++ b/data-model/common/referenceable.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "referenceable",
+  "type": "object",
+  "references": {
+    "type": "array",
+    "items": {
+      "AllOf": [
+        {
+          "properties": {
+            "reference_type ": {
+              "type": "string",
+              "enum": [
+                "original-source",
+                "analysis-of-original"
+              ],
+              "description": "An enum detailing what type of information is referenced"
+            },
+            "reference_title": {
+              "type": "string",
+              "description": "A human-readable title for this object"
+            },
+            "reference_url": {
+              "type": "string",
+              "description": "A URL pointing to a copy of the documentation that the reference refers to"
+            },
+            "analysis_by_ref": {
+              "type": "string",
+              "description": "A direct reference containing the Object ID of the Identity who produced or performed the analysis contained in the referenced document. This is not the Identity of who created the STIX Object, but is who performed the analaysis contained in the referenced document. This Object is not related using a Relationship Object as an intermediatary"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/data-model/stix/asset.json
+++ b/data-model/stix/asset.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-	"title": "campaign",
-  "description": "Sustained attack with a defined intent",
-	"type": "object",
+  "title": "asset",
+  "description": "The Asset object is used to describe something that belongs to an organization (either friendly or hostile)",
+  "type": "object",
   "allOf": [
     {
       "$ref": "../common/core.json"

--- a/data-model/stix/asset.json
+++ b/data-model/stix/asset.json
@@ -15,29 +15,25 @@
     },
     {
       "properties": {
-        "type": {
+        "variety": {
           "type": "string",
-          "enum": ["campaign"]
+          "enum": [
+            "Media - Documents",
+            "Network - Router",
+            "People - Executive",
+            "Server - Mainframe"
+          ],
+          "description": "What variety of asset this Asset object represents. Field purloined from VERIS Asset classification"
         },
-        "impact": {
-          "$ref": "../common/impact.json",
-          "description": "The impact of this campaign on operations (assuming the organization is under attack)"
+        "compromised": {
+          "type": "boolean",
+          "description": "Is the asset compromised?"
         },
-        "status": {
-          "type": "object",
-          "description": "The status of this campaign (historic, ongoing, or future)",
-          "allOf": [
-            {"$ref": "../common/statement.json"},
-            {
-              "properties": {
-                "value": {
-                  "enum": ["Historic", "Ongoing", "Future"]
-                }
-              }
-            }
-          ]
+        "owner_aware": {
+          "type": "boolean",
+          "description": "Is the owner aware the asset is compromised?"
         }
-    	}
+      }
     }
   ],
   "relationships": {

--- a/data-model/stix/course-of-action.json
+++ b/data-model/stix/course-of-action.json
@@ -11,6 +11,9 @@
       "$ref": "../common/describable.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "type": {
           "type": "string",

--- a/data-model/stix/exploit-target-base.json
+++ b/data-model/stix/exploit-target-base.json
@@ -11,6 +11,9 @@
       "$ref": "../common/describable.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "impact": {
           "description": "The impact of this vulnerability were it to be exploited",

--- a/data-model/stix/indicator.json
+++ b/data-model/stix/indicator.json
@@ -8,6 +8,9 @@
       "$ref": "../common/core.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "pattern": {
           "$ref": "#/definitions/pattern",

--- a/data-model/stix/investigation.json
+++ b/data-model/stix/investigation.json
@@ -11,6 +11,9 @@
       "$ref": "../common/describable.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "type": {
           "type": "string",

--- a/data-model/stix/kill-chain-phase.json
+++ b/data-model/stix/kill-chain-phase.json
@@ -8,6 +8,9 @@
       "$ref": "../common/describable.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "id": {
           "type": "string",

--- a/data-model/stix/kill-chain.json
+++ b/data-model/stix/kill-chain.json
@@ -11,6 +11,9 @@
       "$ref": "../common/describable.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "type": {
           "type": "string",

--- a/data-model/stix/observation.json
+++ b/data-model/stix/observation.json
@@ -8,6 +8,9 @@
       "$ref": "../common/core.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "type": {
           "type": "string",

--- a/data-model/stix/relationship.json
+++ b/data-model/stix/relationship.json
@@ -8,6 +8,9 @@
       "$ref": "../common/core.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "type": {
           "type": "string",

--- a/data-model/stix/report.json
+++ b/data-model/stix/report.json
@@ -11,6 +11,9 @@
       "$ref": "../common/describable.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "type": {
           "type": "string",

--- a/data-model/stix/threat-actor.json
+++ b/data-model/stix/threat-actor.json
@@ -11,6 +11,9 @@
       "$ref": "../common/describable.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "type": {
           "type": "string",

--- a/data-model/stix/ttp-base.json
+++ b/data-model/stix/ttp-base.json
@@ -10,6 +10,9 @@
       "$ref": "../common/describable.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "impact": {
           "$ref": "../common/impact.json",

--- a/data-model/stix/victim-targeting.json
+++ b/data-model/stix/victim-targeting.json
@@ -8,6 +8,9 @@
       "$ref": "../common/core.json"
     },
     {
+      "$ref": "../common/referenceable.json"
+    },
+    {
       "properties": {
         "type": {
           "type": "string",


### PR DESCRIPTION
This series of commits adds the referenceable property group to most of the objects within TWIGS. It also adds a new Asset object to the data model.

TODO - the Asset object relationships are all wrong. This will be fixed when we update the relationships.
